### PR TITLE
properly support slog's "dynamic-keys" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-gelf"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Gleb Pomykalov <gleb@pomykalov.ru>", "hedgar <hedgar2017@gmail.com>"]
 build = "build.rs"
 description = "GELF drain for slog"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/lancastr/slog-gelf"
 readme = "README.md"
 
 [dependencies]
-slog = "2.4.1"
+slog = "2.5"
 chrono = "0.4.6"
 rand = "0.6.5"
 serde = "1.0.92"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,11 +37,11 @@ impl Gelf {
     }
 }
 
-pub struct KeyValueList(pub Vec<(&'static str, String)>);
+pub struct KeyValueList(pub Vec<(Key, String)>);
 
 impl slog::Serializer for KeyValueList {
     fn emit_arguments(&mut self, key: Key, val: &std::fmt::Arguments) -> slog::Result {
-        self.0.push((key as &'static str, format!("{}", val)));
+        self.0.push((key, format!("{}", val)));
         Ok(())
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,5 @@
 use serde::ser::{Serialize, SerializeMap, Serializer};
+use slog::Key;
 
 use level::Level;
 
@@ -13,7 +14,7 @@ pub struct Message<'a> {
     pub file: Option<&'static str>,
     pub line: Option<u32>,
     pub column: Option<u32>,
-    pub additional: Vec<(&'static str, String)>,
+    pub additional: Vec<(Key, String)>,
 }
 
 impl<'a> Serialize for Message<'a> {


### PR DESCRIPTION
Hi! Thanks for building `slog-gelf`!

Currently it is broken is the "dynamic-keys" feature is enabled for `slog`. This PR should fix it.

Cheers!